### PR TITLE
add new API function: DbgCli_Node::getParentNode()

### DIFF
--- a/DbgCliNode.cpp
+++ b/DbgCliNode.cpp
@@ -81,16 +81,17 @@ DbgCli_Node* DbgCli_Node::getNode(const char* parentPath, const char* nodeName)
 }
 
 DbgCli_Node::DbgCli_Node(DbgCli_Node* parentNode, const char* nodeName, const char* helpText)
-: m_nodeName(nodeName)
+: m_parentNode(parentNode)
+, m_nodeName(nodeName)
 , m_helpText(helpText)
 , m_sibling(0)
 {
   DbgCli_Node* rootNode = DbgCli_Node::RootNode();
   if (0 != rootNode) // not possible to add nodes, without root node
   {
-    DbgCli_Topic* parentTopic = static_cast<DbgCli_Topic*>(parentNode);
-    if (0 != parentTopic)
+    if (0 != m_parentNode)
     {
+      DbgCli_Topic* parentTopic = static_cast<DbgCli_Topic*>(m_parentNode);
       parentTopic->addChildNode(this);
     }
   }

--- a/DbgCliNode.h
+++ b/DbgCliNode.h
@@ -35,6 +35,12 @@ protected:
 
 public:
   /**
+   * Get parent node.
+   * @return DbgCli_Node Pointer to the parent node object.
+   */
+  virtual DbgCli_Node* getParentNode() { return m_parentNode; }
+
+  /**
    * Get a child node by name (no grandchildren).
    * Command nodes return always null, since these objects don't have any children.
    * @param nodeName Child node object name.
@@ -86,6 +92,7 @@ public:
 
 private:
   static DbgCli_Node* s_rootNode;
+  DbgCli_Node* m_parentNode;
 
 private:
   const char* m_nodeName;

--- a/README.md
+++ b/README.md
@@ -1,2 +1,2 @@
 # debug-cli
-Debug CLI for Embedded Applications - modular and object oriented tree structure.
+Debug CLI for Embedded Applications - modular and object oriented command tree structure.

--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=debug-cli
-version=1.2.0
+version=1.3.0
 author=aschoepfer
 maintainer=dniklaus,aschoepfer
 sentence=Debug CLI for Embedded Applications - Command Line Interface for debugging and testing based on an object oriented tree structure.


### PR DESCRIPTION
- eases creating usage functions when the parent node name shall be printed
- clears the way for a future API fuction which will automatically print out the path string of a node